### PR TITLE
Move profile image to the left

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -400,10 +400,6 @@ $hover-brightness: 0.8;
     margin-bottom: 10px;
   }
 
-  .profile-img {
-    margin: 0px 30px;
-  }
-
   $coin_size: 15px;
   $coin_margin: 3px;
 

--- a/styles/blades.css
+++ b/styles/blades.css
@@ -566,9 +566,6 @@
 * #alias {
   margin-bottom: 10px;
 }
-* .profile-img {
-  margin: 0px 30px;
-}
 * .coins {
   display: flex;
   /* Hide the browser's default checkbox */

--- a/templates/actor-sheet.html
+++ b/templates/actor-sheet.html
@@ -2,6 +2,8 @@
 
   <section id="name-alias" class="flex-horizontal">
 
+    <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
+
     <div class="grow-two">
       <div id="name">
         <label for="character-{{actor._id}}-name">{{localize "BITD.Name"}}</label>
@@ -72,8 +74,6 @@
 
       </div>
     </div>
-
-    <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
 
     <div class="grow-two">
       <div id="alias">

--- a/templates/actor-sheet.html
+++ b/templates/actor-sheet.html
@@ -2,7 +2,7 @@
 
   <section id="name-alias" class="flex-horizontal">
 
-    <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
+    <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
 
     <div class="grow-two">
       <div id="name">

--- a/templates/crew-sheet.html
+++ b/templates/crew-sheet.html
@@ -2,6 +2,8 @@
 
   <section class="flex-horizontal">
 
+    <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
+
     <div id="name-alias" class="grow-two flex-column">
       <div id="name">
         <label for="crew-name">{{localize "BITD.Name"}}</label>
@@ -25,8 +27,6 @@
         {{/each}}
       </div>
     </div>
-  
-    <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
 
     <div class="grow-two flex-vertical">
       <div id="lair">

--- a/templates/crew-sheet.html
+++ b/templates/crew-sheet.html
@@ -2,7 +2,7 @@
 
   <section class="flex-horizontal">
 
-    <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
+    <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
 
     <div id="name-alias" class="grow-two flex-column">
       <div id="name">

--- a/templates/items/ability.html
+++ b/templates/items/ability.html
@@ -1,6 +1,6 @@
 <form class="{{cssClass}}" autocomplete="off">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+        <img src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize 'BITD.Name'}}"/></h1>
         </div>

--- a/templates/items/class.html
+++ b/templates/items/class.html
@@ -1,6 +1,6 @@
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
-      <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+      <img src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
       <div class="header-fields">
           <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize 'BITD.Name'}}"/></h1>
       </div>

--- a/templates/items/cohort.html
+++ b/templates/items/cohort.html
@@ -1,7 +1,7 @@
 <form class="{{cssClass}}" autocomplete="off">
 
   <header class="sheet-header">
-      <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+      <img src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
       <div class="header-fields">
           <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize 'BITD.Name'}}"/></h1>
       </div>

--- a/templates/items/crew_ability.html
+++ b/templates/items/crew_ability.html
@@ -1,6 +1,6 @@
 <form class="{{cssClass}}" autocomplete="off">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+        <img src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize 'BITD.Name'}}"/></h1>
         </div>

--- a/templates/items/crew_type.html
+++ b/templates/items/crew_type.html
@@ -1,6 +1,6 @@
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
-      <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+      <img src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
       <div class="header-fields">
           <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize 'BITD.Name'}}"/></h1>
       </div>

--- a/templates/items/crew_upgrade.html
+++ b/templates/items/crew_upgrade.html
@@ -1,6 +1,6 @@
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
-      <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+      <img src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
       <div class="header-fields">
           <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize 'BITD.Name'}}"/></h1>
       </div>

--- a/templates/items/item.html
+++ b/templates/items/item.html
@@ -1,6 +1,6 @@
 <form class="{{cssClass}}" autocomplete="off">
     <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+        <img src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
         <div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize 'BITD.Name'}}"/></h1>
         </div>

--- a/templates/items/simple.html
+++ b/templates/items/simple.html
@@ -1,6 +1,6 @@
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
-      <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+      <img src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
       <div class="header-fields">
           <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize 'BITD.Name'}}"/></h1>
       </div>


### PR DESCRIPTION
This is a small PR to move the profile image on actor and crew sheets to the left.

This may be subjective, but I think it looks more organized like this. Plus, it allows us to get rid of a CSS class, which is always a good thing in my opinion.

Here is the actor sheet before and after:
- Before: https://user-images.githubusercontent.com/12234562/101533434-1da28580-3996-11eb-9fa3-4c74053226a2.jpg
- After: https://user-images.githubusercontent.com/12234562/101533499-3317af80-3996-11eb-9967-f167fc8a5ebe.jpg

Here is the crew sheet before and after:
- Before: https://user-images.githubusercontent.com/12234562/101533666-665a3e80-3996-11eb-80d1-1140d3e2da66.jpg
- After: https://user-images.githubusercontent.com/12234562/101533699-6d814c80-3996-11eb-90dd-19df3466b07c.jpg

Here is a compendium element before and after:
- Before: https://user-images.githubusercontent.com/12234562/101533803-96a1dd00-3996-11eb-8743-234b4f56aa7a.jpg
- After: https://user-images.githubusercontent.com/12234562/101533817-9d305480-3996-11eb-9178-f09630b612b8.jpg
