### PR TITLE
Improve sheets to be able to add the french version

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -164,6 +164,11 @@
   "BITD.Position": "Position",
   "BITD.Effect": "Effect",
   "BITD.Modifier": "Modifier",
+  
+  "BITD.Light": "light",
+  "BITD.Normal": "normal",
+  "BITD.Encumbered": "encumbered",
+  "BITD.OverMax": "over max",
 
   "BITD.Drain": "Drain",
   "BITD.Wear": "Wear",

--- a/module/blades-actor-sheet.js
+++ b/module/blades-actor-sheet.js
@@ -30,10 +30,10 @@ export class BladesActorSheet extends BladesSheet {
     data.data.loadout = loadout;
     
     // Encumbrance Levels
-    let load_level=["light","light","light","light","normal","normal","heavy","Encumbered",
-			"Encumbered","Encumbered","over max"];
-    let mule_level=["light","light","light","light","light","light","normal","normal",
-			"heavy","Encumbered","over max"];
+    let load_level=["BITD.Light","BITD.Light","BITD.Light","BITD.Light","BITD.Normal","BITD.Normal","BITD.Heavy","BITD.Encumbered",
+			"BITD.Encumbered","BITD.Encumbered","BITD.OverMax"];
+    let mule_level=["BITD.Light","BITD.Light","BITD.Light","BITD.Light","BITD.Light","BITD.Light","BITD.Normal","BITD.Normal",
+			"BITD.Heavy","BITD.Encumbered","BITD.OverMax"];
     let mule_present=0;
  
     //Sanity Check

--- a/module/blades-crew-sheet.js
+++ b/module/blades-crew-sheet.js
@@ -11,7 +11,7 @@ export class BladesCrewSheet extends BladesSheet {
 	  return mergeObject(super.defaultOptions, {
   	  classes: ["blades-in-the-dark", "sheet", "actor"],
   	  template: "systems/blades-in-the-dark/templates/crew-sheet.html",
-      width: 930,
+      width: 940,
       height: 1020,
       tabs: [{navSelector: ".tabs", contentSelector: ".tab-content", initial: "turfs"}]
     });

--- a/module/blades-item-sheet.js
+++ b/module/blades-item-sheet.js
@@ -9,7 +9,7 @@ export class BladesItemSheet extends ItemSheet {
 
 	  return mergeObject(super.defaultOptions, {
 			classes: ["blades-in-the-dark", "sheet", "item"],
-			width: 'auto',
+			width: 560,
 			height: 'auto',
       tabs: [{navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description"}]
 		});

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -80,7 +80,7 @@ $hover-brightness: 0.8;
 
   .editor,
   .editor-content {
-    min-height: 280px;
+    min-height: 150px;
   }
 
   .flex-horizontal {
@@ -453,10 +453,16 @@ $hover-brightness: 0.8;
 
   // Turfs.
 
+  #turf-container {
+    overflow-x: scroll;
+    overflow-y: clip;
+  }
+
   #turf-list {
 
     display: flex;
     flex-direction: column;
+    width: 855px;
 
     .turf-row {
       display: flex;

--- a/styles/blades.css
+++ b/styles/blades.css
@@ -74,7 +74,7 @@
 }
 * .editor,
 * .editor-content {
-  min-height: 280px;
+  min-height: 150px;
 }
 * .flex-horizontal {
   display: flex;
@@ -693,9 +693,14 @@
 * #crew-reputation input[disabled=disabled] + label {
   background-image: url(assets/teeth/stresstooth-black.png);
 }
+* #turf-container {
+  overflow-x: scroll;
+  overflow-y: clip;
+}
 * #turf-list {
   display: flex;
   flex-direction: column;
+  width: 855px;
 }
 * #turf-list .turf-row {
   display: flex;

--- a/templates/actor-sheet.html
+++ b/templates/actor-sheet.html
@@ -272,7 +272,7 @@
             <div class="item flex-horizontal" data-item-id="{{item._id}}">
               <div class="item-body flex-horizontal">
                 <b><div class="item-name">{{item.name}}</div></b>
-                <div class="item-description">{{item.data.description}}</div>
+                <div class="item-description">{{{item.data.description}}}</div>
               </div>
               <a class="item-control item-delete" title="{{localize 'BITD.TitleDeleteItem'}}"><i class="fas fa-trash"></i></a>
             </div>
@@ -285,7 +285,7 @@
       {{!-- Owned Items Tab --}}
       <div id="loadout" class="tab flex-vertical" data-tab="loadout">
         <div class="label-stripe flex-horizontal">
-           <p>{{localize "BITD.Loadout"}}: {{data.loadout}}/{{data.load_level}} </p>
+           <p>{{localize "BITD.Loadout"}}: {{data.loadout}}/{{localize data.load_level}} </p>
           <p><a class="item-add-popup" data-item-type="item"><i class="fas fa-plus-square"></i></a></p>
         </div>
         <div>
@@ -295,7 +295,7 @@
               <div class="item-body flex-horizontal">
                 <img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/>
                 <div class="item-name">{{item.name}}</div>
-                <div class="item-description">{{item.data.description}}</div>
+                <div class="item-description">{{{item.data.description}}}</div>
               </div>
               <a class="item-control item-delete" title="{{localize 'BITD.TitleDeleteItem'}}"><i class="fas fa-trash"></i></a>
             </div>

--- a/templates/crew-sheet.html
+++ b/templates/crew-sheet.html
@@ -30,7 +30,7 @@
 
     <div class="grow-two flex-vertical">
       <div id="lair">
-        <label for="crew-lair">Lair</label>
+        <label for="crew-lair">{{localize "BITD.Lair"}}</label>
         <input type="text" id="crew-lair" name="data.lair" value="{{data.lair}}">
       </div>
 
@@ -224,7 +224,7 @@
     {{!-- Crew XP --}}
     <div class="flex-fertical">
       <div class="big-teeth-section">
-        <div class="big-teeth">
+        <div id="crew-xp" class="big-teeth">
           <label class="black-label" for="crew-experience-0">{{localize "BITD.CrewXP"}}</label>
           {{#multiboxes data.experience}}
           <input type="radio" id="crew-experience-0" name="data.experience" value="0" dtype="Radio">
@@ -275,7 +275,7 @@
         <div class="item flex-horizontal" data-item-id="{{item._id}}">
           <div class="item-body item-sheet-open flex-horizontal">
             <b><div class="item-name">{{item.name}}</div></b>
-            <div class="item-description">{{item.data.description}}</div>
+            <div class="item-description">{{{item.data.description}}}</div>
           </div>
           <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
         </div>
@@ -294,7 +294,7 @@
         <div class="item flex-horizontal" data-item-id="{{item._id}}">
           <div class="item-body item-sheet-open flex-horizontal">
             <b><div class="item-name">{{item.name}}</div></b>
-            <div class="item-description">{{item.data.description}}</div>
+            <div class="item-description">{{{item.data.description}}}</div>
           </div>
           <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
         </div>

--- a/templates/items/ability.html
+++ b/templates/items/ability.html
@@ -8,7 +8,7 @@
     
     {{!-- Sheet Body --}}
     <section class="sheet-body">
-      <textarea name="data.description">{{data.description}}</textarea>
+      {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
     </section>
     <div class="flex-vertical">
       <label class="label-stripe">{{localize "BITD.AbilityPrice"}}</label>

--- a/templates/items/class.html
+++ b/templates/items/class.html
@@ -18,7 +18,7 @@
 
     {{isG}}
     <label class="label-stripe">{{localize "BITD.Logic"}}</label>
-    {{editor content=data.logic target="data.logic" button=true owner=owner editable=editable}}
+    <textarea name="data.logic">{{data.logic}}</textarea>
   </section>
 
 </form>

--- a/templates/items/class.html
+++ b/templates/items/class.html
@@ -8,17 +8,17 @@
   
   <section class="flex-vertical">
     <label class="label-stripe">{{localize "BITD.Description"}}</label>
-    <textarea name="data.description">{{data.description}}</textarea>
+    {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
     <label class="label-stripe">{{localize "BITD.ExpClues"}}</label>
     <div><i>- {{localize "BITD.ClassExpClue1"}}</i></div>
     <div>{{localize "BITD.ClassExpClueDescription"}}</div>
     <div><i>- {{localize "BITD.ClassExpClue2"}}</i></div>
     <div><i>- {{localize "BITD.ClassExpClue3"}}</i></div>
-    <textarea name="data.experience_clues">{{data.experience_clues}}</textarea>
+    {{editor content=data.experience_clues target="data.experience_clues" button=true owner=owner editable=editable}}
 
     {{isG}}
     <label class="label-stripe">{{localize "BITD.Logic"}}</label>
-    <textarea name="data.logic">{{data.logic}}</textarea>
+    {{editor content=data.logic target="data.logic" button=true owner=owner editable=editable}}
   </section>
 
 </form>

--- a/templates/items/crew_ability.html
+++ b/templates/items/crew_ability.html
@@ -8,13 +8,13 @@
     
     {{!-- Sheet Body --}}
     <section class="sheet-body">
-      <textarea name="data.description">{{data.description}}</textarea>
+      {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
     </section>
     
     <div class="flex-vertical">
       <label class="label-stripe">{{localize "BITD.AbilityPrice"}}</label>
       <input id="ability-price" type="text" name="data.price" value="{{data.price}}" placeholder="{{localize 'BITD.AbilityPrice'}}">
-      <label class="label-stripe">{{localize "BITD.AbilityClass"}}</label>
+      <label class="label-stripe">{{localize "BITD.GangType"}}</label>
       <input id="ability-class" type="text" name="data.class" value="{{data.class}}" placeholder="{{localize 'BITD.AbilityClass'}}">
     </div>
 </form>

--- a/templates/items/crew_ability.html
+++ b/templates/items/crew_ability.html
@@ -14,7 +14,7 @@
     <div class="flex-vertical">
       <label class="label-stripe">{{localize "BITD.AbilityPrice"}}</label>
       <input id="ability-price" type="text" name="data.price" value="{{data.price}}" placeholder="{{localize 'BITD.AbilityPrice'}}">
-      <label class="label-stripe">{{localize "BITD.GangType"}}</label>
+      <label class="label-stripe">{{localize "BITD.AbilityClass"}}</label>
       <input id="ability-class" type="text" name="data.class" value="{{data.class}}" placeholder="{{localize 'BITD.AbilityClass'}}">
     </div>
 </form>

--- a/templates/items/crew_type.html
+++ b/templates/items/crew_type.html
@@ -8,10 +8,11 @@
 
   <section class="flex-vertical">
     <label class="label-stripe">{{localize "BITD.Description"}}</label>
-    <textarea name="data.description">{{data.description}}</textarea>
+    {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
     <label class="label-stripe">{{localize "BITD.ExpClues"}}</label>
-    <textarea name="data.experience_clues">{{data.experience_clues}}</textarea>
+    {{editor content=data.experience_clues target="data.experience_clues" button=true owner=owner editable=editable}}
+  
+    <label class="label-stripe">{{localize "BITD.Turf"}}</label>
+    <div id="turf-container">{{> "systems/blades-in-the-dark/templates/parts/turf-list.html" turfs_data=data.turfs can_edit=true editable=editable}}</div>
   </section>
-
-  {{> "systems/blades-in-the-dark/templates/parts/turf-list.html" turfs_data=data.turfs can_edit=true editable=editable}}
 </form>

--- a/templates/items/crew_upgrade.html
+++ b/templates/items/crew_upgrade.html
@@ -9,7 +9,7 @@
   {{!-- Sheet Body --}}
   <section class="sheet-body flex-vertical">
     <label class="label-stripe">{{localize "BITD.Description"}}</label>
-    <textarea name="data.description">{{data.description}}</textarea>
+    {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
     <label class="label-stripe">{{localize "BITD.CrewType"}}</label>
     <input type="text" name="data.class" value="{{data.class}}">
     <label class="label-stripe">{{localize "BITD.Price"}}</label>

--- a/templates/items/item.html
+++ b/templates/items/item.html
@@ -8,7 +8,7 @@
     
     {{!-- Sheet Body --}}
     <section class="sheet-body flex-vertical">
-      <textarea name="data.description">{{data.description}}</textarea>
+      {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
       <label class="label-stripe">{{localize "BITD.Loadout"}}</label>
       <input id="item-load" type="text" name="data.load" value="{{data.load}}">
       <label class="label-stripe">{{localize "BITD.Class"}}</label>

--- a/templates/items/simple.html
+++ b/templates/items/simple.html
@@ -9,6 +9,6 @@
   {{!-- Sheet Body --}}
   <section class="sheet-body flex-vertical">
     <label class="label-stripe">{{localize "BITD.Description"}}</label>
-    <textarea rows="20" name="data.description">{{data.description}}</textarea>
+    {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
   </section>
 </form>

--- a/templates/parts/turf-list.html
+++ b/templates/parts/turf-list.html
@@ -40,7 +40,7 @@
         {{else}}
           <p class="turf-name">{{localize turf.name}}</p>
           {{#if turf.description}}
-          <p class="turf-description">{{localize turf.description}}</p>
+          <p class="turf-description">{{{localize turf.description}}}</p>
           {{/if}}
           {{#noteq id "8"}}
           <a class="turf-control turf-select" title="Select" data-turf-id="{{id}}" data-turf-status="{{turf.value}}"><i class="fas fa-circle"></i></a>


### PR DESCRIPTION
The french version of the compendium uses bold and italic so I had to change the way it is edited and displayed.

French take more space, I couldn't fixes all the issues with a dedicated css sheet.

The french translation will include the compendium and leverage babele. So it will be distributed in a separated module.