### PR TITLE
Properly sort item lists alphabetically

### DIFF
--- a/module/blades-helpers.js
+++ b/module/blades-helpers.js
@@ -177,7 +177,11 @@ export class BladesHelpers {
     compendium_items = compendium_content.map(e => {return e.data});
 
     list_of_items = game_items.concat(compendium_items);
-
+    list_of_items.sort(function(a, b) {
+      let nameA = a.name.toUpperCase();
+      let nameB = b.name.toUpperCase();
+      return nameA.localeCompare(nameB);
+    });
     return list_of_items;
 
   }

--- a/templates/items/faction.html
+++ b/templates/items/faction.html
@@ -17,7 +17,7 @@
 	<label class="label-stripe">{{localize "BITD.Notes"}}</label>
     <textarea rows="2" name="data.notes">{{data.notes}}</textarea>
     
-    {{#if isGm }}
+    {{#if isGM }}
         <label class="label-stripe">{{localize "BITD.Goal"}}</label>
         Clock {{data.goal_1_clock_max}}:<br>{{data.goal_1}}<br><br>
         Clock {{data.goal_2_clock_max}}:<br>{{data.goal_2}}<br><br>


### PR DESCRIPTION
0.8.x sorts lists by id instead of name by default.  This will return the list sorting to the pre-0.8.x sort by name.