### PR TITLE
Added friends/rivals labels to en.json

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -214,5 +214,16 @@
   "BITD.EffectWarning": "Managing Active Effects within an Owned Item is not currently supported by FoundryVTT and will be added in a subsequent update.",
 
   "BITD.Name": "Name",
-  "BITD.CampaignName": "Campaign Name"
+  "BITD.CampaignName": "Campaign Name",
+
+  "BITD.DangerousFriends": "Dangerous Friends",
+  "BITD.EnemiesRivals": "Enemies and Rivals",
+  "BITD.DeadlyFriends": "Deadly Friends",
+  "BITD.Blank": "",
+  "BITD.CleverFriends": "Clever Friends",
+  "BITD.ShadyFriends": "Shady Friends",
+  "BITD.SlyFriends": "Sly Friends",
+  "BITD.ShrewdFriends": "Shrewd Friends",
+  "BITD.DarkServants": "Dark Servants",
+  "BITD.StrangeFriends": "Strange Friends"
 }


### PR DESCRIPTION
The playbook effects for customizing the name of each playbook's friends/rivals use localization strings that hadn't been added to the localization files. This commit adds those, to the english dictionary as a start.