### PR TITLE
fix faction sheet vanishing on faction delete 

### DIFF
--- a/module/blades-faction-sheet.js
+++ b/module/blades-faction-sheet.js
@@ -9,7 +9,7 @@ export class BladesFactionSheet extends BladesSheet {
   /** @override */
 	static get defaultOptions() {
 	  return foundry.utils.mergeObject(super.defaultOptions, {
-  	  classes: ["blades-in-the-dark", "sheet", "item", "faction"],
+  	  classes: ["blades-in-the-dark", "sheet", "actor", "faction"],
   	  template: "systems/blades-in-the-dark/templates/faction-sheet.html",
       width: 900,
       height: 'auto',


### PR DESCRIPTION
Fix faction sheet being classed as an item and thus vanishing when deleting items from it.

Fixes #162 