### PR TITLE
Added Crew Type Button to Crew Sheet

### DIFF
--- a/templates/crew-sheet.html
+++ b/templates/crew-sheet.html
@@ -25,6 +25,35 @@
           </div>
         {{/if}}
         {{/each}}
+        
+        <div class="item-block flex-horizontal">
+          <div class="item-class-label">
+            <a
+              class="item-add-popup"
+              data-distinct="true"
+              data-item-type="crew_type"
+              >{{localize "BITD.CrewType"}}</a
+            >
+          </div>
+          {{#each actor.items as |item id|}} {{#if (eq item.type "crew_type")}}
+          <div class="item flex-horizontal" data-item-id="{{item._id}}">
+            <div class="item-body flex-horizontal">
+              <img
+                src="{{item.img}}"
+                title="{{item.name}}"
+                width="24"
+                height="24"
+              />
+              <div class="item-name">{{item.name}}</div>
+            </div>
+            <a
+              class="item-control item-delete"
+              title="{{localize 'BITD.TitleDeleteItem'}}"
+              ><i class="fas fa-trash"></i
+            ></a>
+          </div>
+          {{/if}} {{/each}}
+        </div>
       </div>
     </div>
 

--- a/templates/crew-sheet.html
+++ b/templates/crew-sheet.html
@@ -10,50 +10,61 @@
         <input type="text" id="crew-{{actor._id}}-name" name="name" value="{{actor.name}}">
       </div>
   
-      <div class="flex-vertical">
+            <div class="item-block flex-horizontal">
         <div class="item-class-label">
-          <a class="item-add-popup" data-distinct="true" data-item-type="crew_reputation">{{localize "BITD.CrewReputation"}}</a>
+          <a
+            class="item-add-popup"
+            data-distinct="true"
+            data-item-type="crew_reputation"
+            >{{localize "BITD.CrewReputation"}}</a
+          >
         </div>
-        {{#each actor.items as |item id|}}
-        {{#if (eq item.type "crew_reputation")}}
-          <div class="item flex-horizontal" data-item-id="{{item._id}}">
-            <div class="item-body item-sheet-open flex-horizontal">
-              <img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/>
-              <div class="item-name">{{item.name}}</div>
-            </div>
-            <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+        {{#each actor.items as |item id|}} {{#if (eq item.type
+        "crew_reputation")}}
+        <div class="item flex-horizontal" data-item-id="{{item._id}}">
+          <div class="item-body item-sheet-open flex-horizontal">
+            <img
+              src="{{item.img}}"
+              title="{{item.name}}"
+              width="24"
+              height="24"
+            />
+            <div class="item-name">{{item.name}}</div>
           </div>
-        {{/if}}
-        {{/each}}
-        
-        <div class="item-block flex-horizontal">
-          <div class="item-class-label">
-            <a
-              class="item-add-popup"
-              data-distinct="true"
-              data-item-type="crew_type"
-              >{{localize "BITD.CrewType"}}</a
-            >
-          </div>
-          {{#each actor.items as |item id|}} {{#if (eq item.type "crew_type")}}
-          <div class="item flex-horizontal" data-item-id="{{item._id}}">
-            <div class="item-body flex-horizontal">
-              <img
-                src="{{item.img}}"
-                title="{{item.name}}"
-                width="24"
-                height="24"
-              />
-              <div class="item-name">{{item.name}}</div>
-            </div>
-            <a
-              class="item-control item-delete"
-              title="{{localize 'BITD.TitleDeleteItem'}}"
-              ><i class="fas fa-trash"></i
-            ></a>
-          </div>
-          {{/if}} {{/each}}
+          <a class="item-control item-delete" title="Delete Item"
+            ><i class="fas fa-trash"></i
+          ></a>
         </div>
+        {{/if}} {{/each}}
+      </div>
+
+      <div class="item-block flex-horizontal">
+        <div class="item-class-label">
+          <a
+            class="item-add-popup"
+            data-distinct="true"
+            data-item-type="crew_type"
+            >{{localize "BITD.CrewType"}}</a
+          >
+        </div>
+        {{#each actor.items as |item id|}} {{#if (eq item.type "crew_type")}}
+        <div class="item flex-horizontal" data-item-id="{{item._id}}">
+          <div class="item-body item-sheet-open flex-horizontal">
+            <img
+              src="{{item.img}}"
+              title="{{item.name}}"
+              width="24"
+              height="24"
+            />
+            <div class="item-name">{{item.name}}</div>
+          </div>
+          <a
+            class="item-control item-delete"
+            title="{{localize 'BITD.TitleDeleteItem'}}"
+            ><i class="fas fa-trash"></i
+          ></a>
+        </div>
+        {{/if}} {{/each}}
       </div>
     </div>
 


### PR DESCRIPTION
Added a crew_type button to the crew sheet template that allows the players to select a crew type without having to drag one from the compendium. I also reworked the layout of the template a bit to make it look nicer since the button's inclusion shifted things a little bit.