### PR TITLE
Modified Clock Sheet for Customization

### DIFF
--- a/module/blades-clock-sheet.js
+++ b/module/blades-clock-sheet.js
@@ -39,14 +39,7 @@ export class BladesClockSheet extends BladesSheet {
     formData['prototypeToken.texture.src'] = image_path;
     let data = [];
     let update = {
-      img: image_path,
-      width: 1,
-      height: 1,
-      scale: 1,
-      mirrorX: false,
-      mirrorY: false,
-      tint: "",
-      displayName: 50
+      img: image_path
     };
 
     let tokens = this.actor.getActiveTokens();


### PR DESCRIPTION
Removed the factors that update the appearance and formatting of the clock, but not it's actual state, so that GMs can freely adjust it's size, color, and name display settings without frequent resets