### PR TITLE
Fixing 0d rolls from left side controls

### DIFF
--- a/module/blades-roll.js
+++ b/module/blades-roll.js
@@ -215,7 +215,7 @@ export async function simpleRollPopup() {
         icon: "<i class='fas fa-check'></i>",
         label: `Roll`,
         callback: async (html) => {
-          let diceQty = html.find('[name="qty"]')[0].value;
+          let diceQty = parseInt(html.find('[name="qty"]')[0].value, 10);
           let note = html.find('[name="note"]')[0].value;
           await bladesRoll(diceQty,"","","",note);
         },


### PR DESCRIPTION
Convert the number of dice to roll from string to int.  This fixes a bug when you roll 0d that cause it to not actually roll and simply shows a partial success in chat.