### PR TITLE
Fixes awkward spacing of item/ability descriptions and icons in tabs on PC sheets

### DIFF
--- a/styles/blades.css
+++ b/styles/blades.css
@@ -1462,10 +1462,6 @@
 .blades-in-the-dark.actor.pc * .item .item-control {
   flex-grow: 1;
 }
-.blades-in-the-dark.actor.pc * .item .item-body,
-.blades-in-the-dark.actor.pc * .item .item-class-label {
-  width: 100px;
-}
 .blades-in-the-dark.actor.pc * .item-class-label {
   margin-bottom: 10px;
 }


### PR DESCRIPTION
Fixes this:
![image](https://github.com/megastruktur/foundryvtt-blades-in-the-dark/assets/1455026/ed2b74b7-95d7-41bd-879a-6125fcf58c2f)

to this:
![image](https://github.com/megastruktur/foundryvtt-blades-in-the-dark/assets/1455026/caf97299-280c-4321-bf18-7cf62f994f8b)
